### PR TITLE
Iso.associate and Iso.flatten

### DIFF
--- a/src/main/scala/scalaz/parsers/Iso.scala
+++ b/src/main/scala/scalaz/parsers/Iso.scala
@@ -30,10 +30,23 @@ object Iso {
   ): Iso[F, G, (A, (B, C)), ((A, B), C)] =
     new Iso[F, G, (A, (B, C)), ((A, B), C)] {
       override def to: UFV[(A, (B, C)), ((A, B), C)] = {
-        case (a, (b, c)) => F.pure((a -> b) -> c)
+        case (a, (b, c)) => F.pure(((a, b), c))
       }
       override def from: UGV[((A, B), C), (A, (B, C))] = {
-        case ((a, b), c) => G.pure(a -> (b -> c))
+        case ((a, b), c) => G.pure((a, (b, c)))
+      }
+    }
+
+  def flatten[F[_], G[_], A, B, C](
+    implicit F: Applicative[F],
+    G: Applicative[G]
+  ): Iso[F, G, (A, (B, C)), (A, B, C)] =
+    new Iso[F, G, (A, (B, C)), (A, B, C)] {
+      override def to: UFV[(A, (B, C)), (A, B, C)] = {
+        case (a, (b, c)) => F.pure((a, b, c))
+      }
+      override def from: UGV[(A, B, C), (A, (B, C))] = {
+        case (a, b, c) => G.pure((a, (b, c)))
       }
     }
 }
@@ -133,19 +146,5 @@ object Combinators {
           case (a, _) => AG.pure(a)
         }
       }
-
-    def flatten[C](
-      implicit AF: Applicative[F],
-      AG: Applicative[G]
-    ): Iso[F, G, (A, (B, C)), (A, B, C)] = new Iso[F, G, (A, (B, C)), (A, B, C)] {
-      override def to: UFV[(A, (B, C)), (A, B, C)] = {
-        case (a, (b, c)) => AF.pure((a, b, c))
-      }
-
-      override def from: UGV[(A, B, C), (A, (B, C))] = {
-        case (a, b, c) => AG.pure(a -> (b -> c))
-      }
-    }
-
   }
 }

--- a/src/test/scala/scalaz/parsers/IsoSpec.scala
+++ b/src/test/scala/scalaz/parsers/IsoSpec.scala
@@ -1,0 +1,65 @@
+package scalaz.parsers
+
+import org.specs2.mutable.Specification
+import scalaz.tc._
+
+class IsoSpec extends Specification {
+
+  private type Id[A]      = A
+  private type TFun[A, B] = A => Id[B]
+  private type TIso[A, B] = Iso[Id, Id, A, B]
+
+  implicit private val idCategory: Category[TFun] = instanceOf(
+    new CategoryClass[TFun] {
+      def id[A]: TFun[A, A]                                          = identity
+      def compose[A, B, C](f: TFun[B, C], g: TFun[A, B]): TFun[A, C] = g.andThen(f)
+    }
+  )
+
+  implicit private val idApplicative: Applicative[Id] = instanceOf(
+    new ApplicativeClass[Id] {
+      def pure[A](a: A): Id[A]                      = a
+      def ap[A, B](fa: Id[A])(f: Id[A => B]): Id[B] = f(fa)
+      def map[A, B](fa: Id[A])(f: A => B): Id[B]    = f(fa)
+    }
+  )
+
+  private def unitL[A](a: A): TIso[Unit, A] = new TIso[Unit, A] {
+    def to: UFV[Unit, A]   = _ => a
+    def from: UGV[A, Unit] = _ => ()
+  }
+
+  private def unitR[A](a: A): TIso[A, Unit] = new TIso[A, Unit] {
+    def to: UFV[A, Unit]   = _ => ()
+    def from: UGV[Unit, A] = _ => a
+  }
+
+  private def verify[A, B](iso: TIso[A, B], a: A, b: B) =
+    (iso.to(a) must_=== b)
+      .and(iso.from(b) must_=== a)
+      .and(iso.from(iso.to(a)) must_=== a)
+
+  "Constructing Iso" >> {
+    "via associate" in {
+      verify(
+        Iso.associate[Id, Id, Int, Long, String],
+        1  -> (2L -> "s"),
+        (1 -> 2L) -> "s"
+      )
+    }
+  }
+
+  "Transforming Iso" >> {
+    "via associate" in {
+      val iso1: TIso[Unit, (Int, (Long, String))] = unitL(1 -> (2L -> "s"))
+      val iso2: TIso[Unit, ((Int, Long), String)] = iso1 >>> Iso.associate
+
+      verify(iso2, (), (1 -> 2L) -> "s")
+
+      val iso3: TIso[((Int, Long), String), Unit] = unitR((1 -> 2L) -> "s")
+      val iso4: TIso[(Int, (Long, String)), Unit] = iso3 <<< Iso.associate
+
+      verify(iso4, 1 -> (2L -> "s"), ())
+    }
+  }
+}


### PR DESCRIPTION
Current version of `associate` being a method of `Iso` instance has some problems.

1. It is an extension method invoked on existing instance of `Iso`, however the result being a new instance of `Iso` does not use the instance it is invoked on. For example
```scala
val iso1: TIso[Unit, (Int, (Long, String))] = ???
val iso2: TIso[(Int, (Long, String)), ((Int, Long), String)] = iso1.associate
```
here it doesn't matter what `iso1` is, as it is just replaced with the fresh instance by `associate`.
In proposed solution we simply have
```scala
val iso2: TIso[(Int, (Long, String)), ((Int, Long), String)] = Iso.associate
```

2. To be exact, extension method invoked on existing instance of `Iso` does use type parameters in a rather unintuitive way, i.e.
```scala
val iso1: TIso[Int, String] = ???
val iso2: TIso[(Int, (String, C)), ((Int, String), C)] = iso1.associate[C]
```

3. In order to use `associate` via `flatMap` we have to construct it by creating a dummy instance first:
```scala
val iso1: TIso[Unit, (Int, (Long, String))] = ???
val iso2: TIso[Unit, ((Int, Long), String)] = iso1 >>> Iso.id.associate
```

This PR changes `Iso.associate` to be a constructor, thus addresses all problems above. Please look at the tests for examples of intended use.

I also tried a different encoding of `associate` as extension method
```scala
    def associate[C, D, E](
      implicit F: Applicative[F], G: Applicative[G], ev: B === (C, (D, E))
    ): Iso[F, G, (C, (D, E)), ((C, D), E)] = ???
```
however it only solves problem 2.

Another way could be to have `.associate` the same as `flatMap(associate)` but I think such approach lacks explicitness.