### PR TITLE
The reverse `~` combinator

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -17,17 +17,9 @@ newlines {
 
 spaces {
   afterKeywordBeforeParen = true
-//  afterSymbolicDefs = true
+  afterSymbolicDefs = true
   inImportCurlyBraces = true
 }
-
-//verticalMultiline {
-//  atDefnSite = true
-//  arityThreshold = 4
-//  newlineAfterOpenParen = true
-//  newlineAfterImplicitKW = true
-//  newlineBeforeImplicitKW = false
-//}
 
 rewrite.rules = [
   AsciiSortImports,

--- a/build.sbt
+++ b/build.sbt
@@ -14,12 +14,13 @@ lazy val root =
   (project in file("."))
     .settings(
       name := "scalaz-parsers",
+      scalacOptions ++= Seq("-Xsource:2.13"),
       resolvers += "Sonatype OSS Staging".at(
         "https://oss.sonatype.org/content/repositories/staging"
       ),
       libraryDependencies ++= Seq(
         "org.scalaz" %% "scalaz-zio"  % "0.2.9",
-        "org.scalaz" %% "scalaz-base" % "96627337-SNAPSHOT",
+        "org.scalaz" %% "scalaz-base" % "e5ebff0a-SNAPSHOT",
         "org.specs2" %% "specs2-core" % "4.3.5" % Test
       )
     )

--- a/src/main/scala/scalaz/parsers/Iso.scala
+++ b/src/main/scala/scalaz/parsers/Iso.scala
@@ -1,5 +1,6 @@
 package scalaz.parsers
 
+import scalaz.data.~>
 import scalaz.tc._
 
 trait Iso[F[_], G[_], A, B] { self =>
@@ -42,11 +43,11 @@ object Combinators {
         override def from: UGV[B, A] = (b: B) => AG.or(ab.from(b), abOther.from(b))
       }
 
-//    def unary_~(implicit GF: G ~> F, FG: F ~> G): Iso[F, G, B, A] =
-//      new Iso[F, G, B, A] {
-//        override def to: UFV[B, A]   = (b: B) => GF.apply(ab.from(b))
-//        override def from: UGV[A, B] = (a: A) => FG.apply(ab.to(a))
-//      }
+    def unary_~(implicit FG: F ~> G, GF: G ~> F): Iso[F, G, B, A] =
+      new Iso[F, G, B, A] {
+        override def to: UFV[B, A]   = b => GF.apply(ab.from(b))
+        override def from: UGV[A, B] = a => FG.apply(ab.to(a))
+      }
 
     def ⓧ [A2, B2](
       other: Iso[F, G, A2, B2]

--- a/src/test/scala/scalaz/parsers/IsoOpsSpec.scala
+++ b/src/test/scala/scalaz/parsers/IsoOpsSpec.scala
@@ -1,0 +1,26 @@
+package scalaz.parsers
+
+import org.specs2.mutable.Specification
+import scalaz.Scalaz.Id
+import scalaz.data.{ ~>, ∀ }
+import scalaz.parsers.Combinators._
+
+class IsoOpsSpec extends Specification {
+
+  private type TIso[A, B] = Iso[Id, Id, A, B]
+
+  private val iso = new TIso[Int, String] {
+    override def to: UFV[Int, String]   = _.toString
+    override def from: UGV[String, Int] = _.toInt
+  }
+
+  implicit private val id: Id ~> Id = ∀.mk[Id ~> Id].from(identity)
+
+  "Transforming Iso" >> {
+    "via reverse" in {
+      iso.to(1) must_=== (~iso).from(1)
+      iso.from("1") must_=== (~iso).to("1")
+      iso.to(1) must_=== (~(~iso)).to(1)
+    }
+  }
+}


### PR DESCRIPTION
Restored the reverse (`~`) combinator and added tests.

There is a `build.sbt` update here that 
1. bumps scalaz-base version to around mid-september snapshot.
2. adds possibility to work will universally quantified functions that are used for natural transformation encoding in v.8. This is also PRed to `scalaz-sbt` plugin here https://github.com/scalaz/scalaz-sbt/pull/22