### PR TITLE
Iso.unit + ProductIso encoding

### DIFF
--- a/src/test/scala/scalaz/parsers/Simplest.scala
+++ b/src/test/scala/scalaz/parsers/Simplest.scala
@@ -57,6 +57,8 @@ object Simplest {
   type PFunction[A, B] = A => Option[B]
   type PIso[A, B]      = Iso[Option, Id, A, B]
 
+  object PIso extends ProductIso[Option, Id]
+
   implicit val categoryOfTotalFunctions: Category[TFunction] = instanceOf(
     new CategoryClass[TFunction] {
       override def id[A]: TFunction[A, A] = identity
@@ -85,7 +87,7 @@ object Simplest {
 
   object Parsers {
     import Combinators._
-    import Iso._
+    import PIso._
     import IsoInstances._
     import ScalazInstances._
     import Syntax._
@@ -108,7 +110,7 @@ object Simplest {
       integer ∘ apply(Number, _.value)
 
     val composition: Parser[Composition] =
-      (number /\ plus /\ number) ∘ (~associate[Option, Id, Number, Char, Number] >>> flatten >>> apply(
+      (number /\ plus /\ number) ∘ (~associate[Number, Char, Number] >>> flatten >>> apply(
         { case (n1, _, n2) => Composition(n1, n2) },
         c => (c.n1, '+', c.n2)
       ))


### PR DESCRIPTION
1. Adds `unitL` and `unitR` constructors for product type.

2. Changes constructor-containing `object Iso` to `trait ProductIso[F[_], G[_]]` (name is chosen due to all types being product types, e.g. tuples). The reason for that is to save on passing `F`s and `G`s around at call site in exchange for having specialization object `object PIso extends ProductIso[Option, Id]`. Please look at the code reduction in tests.