### PR TITLE
Example using the `many` combinator

### DIFF
--- a/src/test/scala/scalaz/parsers/SimplestSpec.scala
+++ b/src/test/scala/scalaz/parsers/SimplestSpec.scala
@@ -2,7 +2,7 @@ package scalaz.parsers
 
 import org.specs2.mutable.Specification
 import scalaz.parsers.Simplest.Parsers
-import scalaz.parsers.Simplest.Syntax.{ Number, Sum }
+import scalaz.parsers.Simplest.Syntax.{ Constant, Sum }
 
 class SimplestSpec extends Specification {
 
@@ -12,11 +12,11 @@ class SimplestSpec extends Specification {
     }
 
     "parse a digit into a literal" in {
-      parse("5") must_=== Right(Nil -> Number(5))
+      parse("5") must_=== Right(Nil -> Constant(5))
     }
 
     "try to parse two digits and finish after first (because it's indeed simplest)" in {
-      parse("55") must_=== Right(List('5') -> Number(5))
+      parse("55") must_=== Right(List('5') -> Constant(5))
     }
 
     "not parse a letter and indicate failure" in {
@@ -28,11 +28,11 @@ class SimplestSpec extends Specification {
     }
 
     "parse sum of 2 numbers" in {
-      parse("5+6") must_=== Right(Nil -> Sum(Number(5), Number(6)))
+      parse("5+6") must_=== Right(Nil -> Sum(Constant(5), Constant(6)))
     }
 
     "parse sum of 3 numbers" in {
-      parse("5+6+7") must_=== Right(Nil -> Sum(Sum(Number(5), Number(6)), Number(7)))
+      parse("5+6+7") must_=== Right(Nil -> Sum(Sum(Constant(5), Constant(6)), Constant(7)))
     }
   }
 

--- a/src/test/scala/scalaz/parsers/SimplestSpec.scala
+++ b/src/test/scala/scalaz/parsers/SimplestSpec.scala
@@ -2,11 +2,15 @@ package scalaz.parsers
 
 import org.specs2.mutable.Specification
 import scalaz.parsers.Simplest.Parsers
-import scalaz.parsers.Simplest.Syntax.{ Composition, Number }
+import scalaz.parsers.Simplest.Syntax.{ Number, Sum }
 
 class SimplestSpec extends Specification {
 
   "Simplest parser" should {
+    "not parse empty input" in {
+      parse("") must_=== Left(())
+    }
+
     "parse a digit into a literal" in {
       parse("5") must_=== Right(Nil -> Number(5))
     }
@@ -23,8 +27,12 @@ class SimplestSpec extends Specification {
       parse("+") must_=== Left(())
     }
 
-    "parse sum as expression" in {
-      parse("5+5") must_=== Right(Nil -> Composition(Number(5), Number(5)))
+    "parse sum of 2 numbers" in {
+      parse("5+6") must_=== Right(Nil -> Sum(Number(5), Number(6)))
+    }
+
+    "parse sum of 3 numbers" in {
+      parse("5+6+7") must_=== Right(Nil -> Sum(Sum(Number(5), Number(6)), Number(7)))
     }
   }
 


### PR DESCRIPTION

1. Added the `many` parser combinator. See tests for what it brings.
2. Added the `foldL` iso combinator as it's described in the paper.
3. No more `Iso[Option, Id, A, B]`: usage of `Iso.reverse` and required partial functions makes it impossible to work with `Id` category.