### PR TITLE
redefined conjunction in terms of two new operations: cross and curl

### DIFF
--- a/src/main/scala/scalaz/parsers/transform.scala
+++ b/src/main/scala/scalaz/parsers/transform.scala
@@ -15,7 +15,7 @@ object syntax extends CategorySyntax
 
 trait TransformClass[=>:[_, _]] extends StrongClass[=>:] with CategoryClass[=>:] {
 
-  implicit val cc: CategoryClass[=>:] = this
+  implicit private val cc: CategoryClass[=>:] = this
 
   import syntax._
 
@@ -120,7 +120,7 @@ object Transform {
 
   trait DeriveTransformFunctions[=>:[_, _]] extends TransformClass[=>:] {
 
-    implicit val self: CategoryClass[=>:] = this
+    implicit private val cc: CategoryClass[=>:] = this
 
     import syntax._
 


### PR DESCRIPTION
Redefined implementations of `TransformClass[=>:[_, _]].conjunction[A, B, C, D](ab: A =>: B, cd: C =>: D): (A /\ C) =>: (B /\ D)` in terms of two new operations:

`TransformClass[=>:[_, _]].cross[A, B, C, D](ab: A =>: B, cd: C =>: D): (A /\ C) =>: (C /\ B, A /\ D)`
and
`TransformClass[=>:[_, _]].curl[A, B, X]: (X /\ (A /\ B)) =>: (B /\ A)`

Note:

Also added a composition operator (`∘`) for `CategoryClass[=>:]`