### PR TITLE
Parsing based on ApplicativeError

### DIFF
--- a/src/main/scala/scalaz/parsers/ParserSyntax.scala
+++ b/src/main/scala/scalaz/parsers/ParserSyntax.scala
@@ -1,8 +1,8 @@
 package scalaz.parsers
 
-trait ParserSyntax[P[_], F[_], G[_]] {
+trait ParserSyntax[P[_], F[_], G[_], E] {
 
-  val parsing: Parsing[F, G]
+  val parsing: Parsing[F, G, E]
 
   def char: P[Char]
 
@@ -22,7 +22,7 @@ trait ParserSyntax[P[_], F[_], G[_]] {
 
   def delay[A](pa: => P[A]): P[A]
 
-  implicit class ParserOps[A](p: P[A]) {
+  implicit final class ParserOps[A](p: P[A]) {
 
     def /\ [B](other: P[B])(implicit P: ProductFunctor[P]): P[A /\ B] =
       and(p, other)

--- a/src/main/scala/scalaz/parsers/applicativeerror.scala
+++ b/src/main/scala/scalaz/parsers/applicativeerror.scala
@@ -1,0 +1,8 @@
+package scalaz.parsers
+
+import scalaz.tc._
+
+trait ApplicativeErrorClass[F[_], E] extends ApplicativeClass[F] {
+  def raiseError[A](e: E): F[A]
+  def handleError[A](fa: F[A])(f: E => F[A]): F[A]
+}

--- a/src/main/scala/scalaz/parsers/implicits.scala
+++ b/src/main/scala/scalaz/parsers/implicits.scala
@@ -1,6 +1,6 @@
 package scalaz.parsers
 
-import scalaz.tc.{ Category, CategoryClass, Monad, instanceOf }
+import scalaz.tc._
 
 object implicits {
 
@@ -13,4 +13,9 @@ object implicits {
           a => F.flatMap(g(a))(f)
       }
     )
+
+  implicit def monadErrorApplicativeError[F[_], E](
+    implicit F: MonadError[F, E]
+  ): ApplicativeError[F, E] =
+    instanceOf(F)
 }

--- a/src/main/scala/scalaz/parsers/monaderror.scala
+++ b/src/main/scala/scalaz/parsers/monaderror.scala
@@ -1,0 +1,27 @@
+package scalaz.parsers
+
+import scalaz.tc.BindClass.DeriveFlatMap
+import scalaz.tc._
+
+trait MonadErrorClass[F[_], E] extends ApplicativeErrorClass[F, E] with MonadClass[F] {}
+
+object MonadErrorClass {
+
+  implicit def eitherMonadError[E](
+    implicit F: Monad[Either[E, ?]]
+  ): MonadError[Either[E, ?], E] =
+    instanceOf(new MonadErrorClass[Either[E, ?], E] with DeriveFlatMap[Either[E, ?]] {
+      override def raiseError[A](e: E): Either[E, A] =
+        Left(e)
+      override def handleError[A](fa: Either[E, A])(f: E => Either[E, A]): Either[E, A] =
+        fa match {
+          case Left(e)      => f(e)
+          case r @ Right(_) => r
+        }
+
+      override def pure[A](a: A): Either[E, A]                                    = F.pure(a)
+      override def ap[A, B](fa: Either[E, A])(f: Either[E, A => B]): Either[E, B] = F.ap(fa)(f)
+      override def map[A, B](ma: Either[E, A])(f: A => B): Either[E, B]           = F.map(ma)(f)
+      override def flatten[A](ma: Either[E, Either[E, A]]): Either[E, A]          = F.flatten(ma)
+    })
+}

--- a/src/main/scala/scalaz/parsers/package.scala
+++ b/src/main/scala/scalaz/parsers/package.scala
@@ -7,8 +7,10 @@ package object parsers {
   type /\[A, B] = (A, B)
   type \/[A, B] = Either[A, B]
 
-  type Alternative[F[_]]    = InstanceOf[AlternativeClass[F]]
-  type ProductFunctor[F[_]] = InstanceOf[ProductFunctorClass[F]]
+  type Alternative[F[_]]         = InstanceOf[AlternativeClass[F]]
+  type ProductFunctor[F[_]]      = InstanceOf[ProductFunctorClass[F]]
+  type ApplicativeError[F[_], E] = InstanceOf[ApplicativeErrorClass[F, E]]
+  type MonadError[F[_], E]       = InstanceOf[MonadErrorClass[F, E]]
 
   type Transform[=>:[_, _]] = InstanceOf[TransformClass[=>:]]
 }

--- a/src/test/scala/scalaz/parsers/CodecSpec.scala
+++ b/src/test/scala/scalaz/parsers/CodecSpec.scala
@@ -1,21 +1,21 @@
 package scalaz.parsers
 
 import org.specs2.mutable.Specification
-import scalaz.tc.Monad
 
 class CodecSpec extends Specification {
 
   "Instantiate Parsing" >> {
     "given instances of applicative and category" in {
       import implicits.monadKleisliCategory
-      import TCInstances.applicativeOption
-      Parsing[Option, Option]()
+      import implicits.monadErrorApplicativeError
+      import TCInstances.applicativeErrorOption
+      Parsing[Option, Option, Unit]()
       success
     }
 
     "given instances of monad" in {
-      val M: Monad[Option] = implicitly
-      Parsing[Option, Option](M, M)
+      val M: MonadError[Option, Unit] = TCInstances0.monadErrorOption
+      Parsing[Option, Option, Unit](M, M)
       success
     }
   }

--- a/src/test/scala/scalaz/parsers/EquivSpec.scala
+++ b/src/test/scala/scalaz/parsers/EquivSpec.scala
@@ -7,7 +7,7 @@ class EquivSpec extends Specification {
   import implicits._
   import TCInstances._
 
-  private val parsing: Parsing[Option, Option] = Parsing()
+  private val parsing: Parsing[Option, Option, Unit] = Parsing()
   private type Equiv[A, B] = parsing.Equiv[A, B]
 
   private def verify[A, B](equiv: Equiv[A, B], a: A, b: B) =

--- a/src/test/scala/scalaz/parsers/ParserSyntaxSpec.scala
+++ b/src/test/scala/scalaz/parsers/ParserSyntaxSpec.scala
@@ -7,11 +7,13 @@ class ParserSyntaxSpec extends Specification {
 
   private type Parser[A] = String => (String, List[A])
 
-  private object Parser extends ParserSyntax[Parser, Option, Option] {
+  private object Parser extends ParserSyntax[Parser, Option, Option, Unit] {
+    import implicits._
     import Instances._
+    import TCInstances._
 
-    override val parsing: Parsing[Option, Option] =
-      Parsing[Option, Option]
+    override val parsing: Parsing[Option, Option, Unit] =
+      Parsing[Option, Option, Unit]
 
     override def char: Parser[Char] =
       s => s.headOption.fold("" -> List.empty[Char])(h => s.drop(1) -> List(h))

--- a/src/test/scala/scalaz/parsers/Simplest.scala
+++ b/src/test/scala/scalaz/parsers/Simplest.scala
@@ -87,7 +87,7 @@ object Simplest {
   }
 
   def grammar[P[_]: ProductFunctor: Alternative](
-    P: ParserSyntax[P, Option, Option]
+    P: ParserSyntax[P, Option, Option, Unit]
   ): P[Syntax.Expression] = {
     import Syntax._
     import P._
@@ -164,11 +164,12 @@ object Simplest {
     expression
   }
 
-  object Parser extends ParserSyntax[Parser, Option, Option] {
+  object Parser extends ParserSyntax[Parser, Option, Option, Unit] {
     import ScalazInstances._
+    import TCInstances._
 
-    override val parsing: Parsing[Option, Option] =
-      Parsing[Option, Option]
+    override val parsing: Parsing[Option, Option, Unit] =
+      Parsing[Option, Option, Unit]
 
     override def char: Parser[Char] = {
       case head :: tail => Right(tail -> head)
@@ -193,11 +194,12 @@ object Simplest {
       pa(_)
   }
 
-  object Printer extends ParserSyntax[Printer, Option, Option] {
+  object Printer extends ParserSyntax[Printer, Option, Option, Unit] {
     import ScalazInstances._
+    import TCInstances._
 
-    override val parsing: Parsing[Option, Option] =
-      Parsing[Option, Option]
+    override val parsing: Parsing[Option, Option, Unit] =
+      Parsing[Option, Option, Unit]
 
     override def char: Printer[Char] =
       _.toString

--- a/src/test/scala/scalaz/parsers/TCInstances.scala
+++ b/src/test/scala/scalaz/parsers/TCInstances.scala
@@ -1,14 +1,19 @@
 package scalaz.parsers
 
 import scalaz.data.{ ~>, ∀ }
+import scalaz.parsers.implicits.monadErrorApplicativeError
+import scalaz.tc.BindClass.DeriveFlatMap
 import scalaz.tc.FoldableClass.{ DeriveFoldMap, DeriveToList }
-import scalaz.tc.{ Applicative, Foldable, FoldableClass, instanceOf }
+import scalaz.tc._
 
 object TCInstances {
   import scalaz.Scalaz.monadApplicative
 
   implicit val applicativeOption: Applicative[Option] =
     monadApplicative[Option](implicitly)
+
+  implicit val applicativeErrorOption: ApplicativeError[Option, Unit] =
+    monadErrorApplicativeError[Option, Unit](TCInstances0.monadErrorOption)
 
   implicit val foldableOption: Foldable[Option] = instanceOf(
     new FoldableClass[Option] with DeriveFoldMap[Option] with DeriveToList[Option] {
@@ -21,4 +26,22 @@ object TCInstances {
 
   implicit val OptionToOption: Option ~> Option =
     ∀.mk[Option ~> Option].from(identity)
+}
+
+object TCInstances0 {
+
+  val monadErrorOption: MonadError[Option, Unit] = {
+    val F: Monad[Option] = implicitly
+    instanceOf(new MonadErrorClass[Option, Unit] with DeriveFlatMap[Option] {
+      override def raiseError[A](e: Unit): Option[A] =
+        None
+      override def handleError[A](fa: Option[A])(f: Unit => Option[A]): Option[A] =
+        fa.orElse(f(()))
+
+      override def pure[A](a: A): Option[A]                              = F.pure(a)
+      override def ap[A, B](fa: Option[A])(f: Option[A => B]): Option[B] = F.ap(fa)(f)
+      override def map[A, B](ma: Option[A])(f: A => B): Option[B]        = F.map(ma)(f)
+      override def flatten[A](ma: Option[Option[A]]): Option[A]          = F.flatten(ma)
+    })
+  }
 }


### PR DESCRIPTION
Closes #29 

It drops the coverage, but I don't want to add example on top of this change, so the coverage will rise in the next change set that uses new feature.