### PR TITLE
Reorganize classes into sub-packages, changed some file names to match class names

### DIFF
--- a/src/main/scala/scalaz/parsers/package.scala
+++ b/src/main/scala/scalaz/parsers/package.scala
@@ -1,5 +1,11 @@
 package scalaz
 
+import scalaz.parsers.tc.{
+  AlternativeClass,
+  ApplicativeErrorClass,
+  MonadErrorClass,
+  ProductFunctorClass
+}
 import scalaz.tc.InstanceOf
 
 package object parsers {

--- a/src/main/scala/scalaz/parsers/syntax/ParserSyntax.scala
+++ b/src/main/scala/scalaz/parsers/syntax/ParserSyntax.scala
@@ -1,4 +1,6 @@
-package scalaz.parsers
+package scalaz.parsers.syntax
+
+import scalaz.parsers._
 
 trait ParserSyntax[P[_], F[_], G[_], E] {
 

--- a/src/main/scala/scalaz/parsers/tc/alternative.scala
+++ b/src/main/scala/scalaz/parsers/tc/alternative.scala
@@ -1,5 +1,6 @@
-package scalaz.parsers
+package scalaz.parsers.tc
 
+import scalaz.parsers.Alternative
 import scalaz.tc.instanceOf
 
 trait AlternativeClass[F[_]] {

--- a/src/main/scala/scalaz/parsers/tc/applicativeerror.scala
+++ b/src/main/scala/scalaz/parsers/tc/applicativeerror.scala
@@ -1,4 +1,4 @@
-package scalaz.parsers
+package scalaz.parsers.tc
 
 import scalaz.tc._
 

--- a/src/main/scala/scalaz/parsers/tc/monaderror.scala
+++ b/src/main/scala/scalaz/parsers/tc/monaderror.scala
@@ -1,5 +1,6 @@
-package scalaz.parsers
+package scalaz.parsers.tc
 
+import scalaz.parsers.MonadError
 import scalaz.tc.BindClass.DeriveFlatMap
 import scalaz.tc._
 

--- a/src/main/scala/scalaz/parsers/tc/productfunctor.scala
+++ b/src/main/scala/scalaz/parsers/tc/productfunctor.scala
@@ -1,4 +1,6 @@
-package scalaz.parsers
+package scalaz.parsers.tc
+
+import scalaz.parsers./\
 
 trait ProductFunctorClass[F[_]] {
   def and[A, B](fa: F[A], fb: F[B]): F[A /\ B]

--- a/src/main/scala/scalaz/parsers/transform.scala
+++ b/src/main/scala/scalaz/parsers/transform.scala
@@ -11,13 +11,13 @@ trait CategorySyntax {
   }
 }
 
-object syntax extends CategorySyntax
+object catSyntax extends CategorySyntax
 
 trait TransformClass[=>:[_, _]] extends StrongClass[=>:] with CategoryClass[=>:] {
 
   implicit private val cc: CategoryClass[=>:] = this
 
-  import syntax._
+  import catSyntax._
 
   def duplicate[A]: A =>: (A /\ A)
 
@@ -122,7 +122,7 @@ object Transform {
 
     implicit private val cc: CategoryClass[=>:] = this
 
-    import syntax._
+    import catSyntax._
 
     override def combine[A, B, C](ab: A =>: B, ac: A =>: C): A =>: (B /\ C) =
       first[A, B, C](ab) ∘ second[A, C, A](ac) ∘ duplicate[A]

--- a/src/test/scala/scalaz/parsers/ParserSyntaxSpec.scala
+++ b/src/test/scala/scalaz/parsers/ParserSyntaxSpec.scala
@@ -1,6 +1,8 @@
 package scalaz.parsers
 
 import org.specs2.mutable.Specification
+import scalaz.parsers.syntax.ParserSyntax
+import scalaz.parsers.tc.{ AlternativeClass, ProductFunctorClass }
 import scalaz.tc._
 
 class ParserSyntaxSpec extends Specification {

--- a/src/test/scala/scalaz/parsers/Simplest.scala
+++ b/src/test/scala/scalaz/parsers/Simplest.scala
@@ -1,6 +1,8 @@
 package scalaz.parsers
 
 import scalaz.data.{ ~>, ∀ }
+import scalaz.parsers.syntax.ParserSyntax
+import scalaz.parsers.tc.{ AlternativeClass, ProductFunctorClass }
 import scalaz.tc.FoldableClass.{ DeriveFoldMap, DeriveToList }
 import scalaz.tc._
 

--- a/src/test/scala/scalaz/parsers/TCInstances.scala
+++ b/src/test/scala/scalaz/parsers/TCInstances.scala
@@ -2,6 +2,7 @@ package scalaz.parsers
 
 import scalaz.data.{ ~>, ∀ }
 import scalaz.parsers.implicits.monadErrorApplicativeError
+import scalaz.parsers.tc.MonadErrorClass
 import scalaz.tc.BindClass.DeriveFlatMap
 import scalaz.tc.FoldableClass.{ DeriveFoldMap, DeriveToList }
 import scalaz.tc._


### PR DESCRIPTION
Reorganized the package/class locations a bit, the rationale for each package is explained as follows:

`tc`: scalaz-parsers type-classes
`shaper`: work-in-progress: Higher level types for parsing tokens into an AST
`tokenizer`: work-in-progress: Higher level types for generating a sequence/stream of tokens from unparsed data.