### PR TITLE
Tracking errors while parsing

### DIFF
--- a/src/main/scala/scalaz/parsers/tc/Alternative.scala
+++ b/src/main/scala/scalaz/parsers/tc/Alternative.scala
@@ -1,5 +1,8 @@
 package scalaz.parsers.tc
 
+import scalaz.{ -\/, EitherT, Monad, \/- }
+import scalaz.syntax.monad._
+
 trait Alternative[F[_]] {
   def or[A](f1: F[A], f2: => F[A]): F[A]
 }
@@ -12,12 +15,21 @@ object Alternative {
         f1.orElse(f2)
     }
 
-  implicit def eitherAlternative[R]: Alternative[Either[R, ?]] =
-    new Alternative[Either[R, ?]] {
-      override def or[A](f1: Either[R, A], f2: => Either[R, A]): Either[R, A] =
+  implicit def eitherAlternative[L]: Alternative[Either[L, ?]] =
+    new Alternative[Either[L, ?]] {
+      override def or[A](f1: Either[L, A], f2: => Either[L, A]): Either[L, A] =
         f1 match {
           case Left(_)  => f2
           case Right(_) => f1
         }
+    }
+
+  implicit def eitherTAlternative[F[_]: Monad, L]: Alternative[EitherT[L, F, ?]] =
+    new Alternative[EitherT[L, F, ?]] {
+      override def or[A](f1: EitherT[L, F, A], f2: => EitherT[L, F, A]): EitherT[L, F, A] =
+        EitherT(f1.run.flatMap {
+          case -\/(_) => f2.run
+          case \/-(_) => f1.run
+        })
     }
 }

--- a/src/main/scala/scalaz/parsers/tc/Category.scala
+++ b/src/main/scala/scalaz/parsers/tc/Category.scala
@@ -3,8 +3,8 @@ package scalaz.parsers.tc
 import scalaz.Monad
 
 trait Category[=>:[_, _]] {
-  def id[A]: =>:[A, A]
-  def compose[A, B, C](f: =>:[B, C], g: =>:[A, B]): =>:[A, C]
+  def id[A]: A =>: A
+  def compose[A, B, C](f: B =>: C, g: A =>: B): A =>: C
 }
 
 object Category {


### PR DESCRIPTION
When parsing something that cannot be parsed, for example `1a` into a number, the result is `Constant(1)` plus the remaining unparsed input `a`. Why the input wasn't consumed completely isn't indicated. The other case is tracing parser execution which is helpful while building the parser logic itself.

This PR shows how easy it is to make parser log its work and output errors when they are encountered.

The syntax and parsing logic is copied from `ClassicExample`, however the effect type is different, and just having a different effect type is enough to implement the desired feature.

```scala
// Effect = Either[Error, Result] + Writer[Position & Error] + State[CurrentPosition]
type Eff[A] = EitherT[String, RWS[Unit, List[Int /\ String], Int, ?], A]
```

Thus parsing `1a` into a number tells that `pos 1: Expected: [0-9]` 🤗
