### PR TITLE
Codec.delay()

### DIFF
--- a/src/main/scala/scalaz/parsers/Parsing.scala
+++ b/src/main/scala/scalaz/parsers/Parsing.scala
@@ -265,6 +265,11 @@ sealed trait Parsing[F[_], G[_], E] {
     def pure[I, A](a: A): Codec[I, A] =
       apply(Equiv.lift[I, (I, A)]((_, a), _._1))
 
+    def delay[I, A](pa: => Codec[I, A]): Codec[I, A] = {
+      lazy val pa0 = pa
+      apply(Equiv(pa0.eq.to(_), pa0.eq.from(_)))
+    }
+
     implicit def parserOps[I]: ParserOps[Codec[I, ?]] = new ParserOps[Codec[I, ?]] {
       import syntax._
 

--- a/src/test/scala/scalaz/parsers/ClassicExampleSpec.scala
+++ b/src/test/scala/scalaz/parsers/ClassicExampleSpec.scala
@@ -87,7 +87,7 @@ class ClassicExampleSpec extends Specification {
       operationExpressionEq(Add)
     )
 
-    lazy val expression: Codec[Expression] = case2
+    val expression: Codec[Expression] = case2
   }
 
   def parse(s: String): Either[String, (String, Syntax.Expression)] =

--- a/src/test/scala/scalaz/parsers/CodecSpec.scala
+++ b/src/test/scala/scalaz/parsers/CodecSpec.scala
@@ -21,4 +21,19 @@ class CodecSpec extends Specification {
       success
     }
   }
+
+  "Codec.delay" should {
+    import Category._
+    import TCInstances.optionApplicativeError
+    val env = Parsing[Option, Option, Unit]()
+    import env._
+
+    "add trampoline to Codec.equiv usage" in {
+      lazy val c1: Codec[String, String] = c2
+      lazy val c2: Codec[String, String] = c1
+      // accessing `c1` via `delay` does not result in stack overflow
+      Codec.delay(c1)
+      success
+    }
+  }
 }

--- a/src/test/scala/scalaz/parsers/DocumentationExampleSpec.scala
+++ b/src/test/scala/scalaz/parsers/DocumentationExampleSpec.scala
@@ -81,7 +81,7 @@ class DocumentationExampleSpec extends Specification {
       operationExpressionEq(Add)
     )
 
-    lazy val expression: P[Expression] = "Expression" @@ case2
+    val expression: P[Expression] = "Expression" @@ case2
   }
 
   object Parsers {

--- a/src/test/scala/scalaz/parsers/ErrorTrackingExampleSpec.scala
+++ b/src/test/scala/scalaz/parsers/ErrorTrackingExampleSpec.scala
@@ -126,7 +126,7 @@ class ErrorTrackingExampleSpec extends Specification {
       operationExpressionEq(Add)
     )
 
-    lazy val expression: Codec[Expression] = case2
+    val expression: Codec[Expression] = case2
   }
 
   def parse(s: String): (List[Int /\ String], String \/ (String, Syntax.Expression)) = {

--- a/src/test/scala/scalaz/parsers/Simplest.scala
+++ b/src/test/scala/scalaz/parsers/Simplest.scala
@@ -96,7 +96,7 @@ object Simplest {
     val case1: P[Expression] =
       (case0 /\ (plus /\ case0).many) ∘ foldl(())(sumExpressionEq)
 
-    lazy val expression: P[Expression] =
+    val expression: P[Expression] =
       case1
 
     expression

--- a/src/test/scala/scalaz/parsers/SimplestCodecSpec.scala
+++ b/src/test/scala/scalaz/parsers/SimplestCodecSpec.scala
@@ -58,7 +58,7 @@ class SimplestCodecSpec extends Specification {
 
     val case1: C[Expression] = (case0 ~ (plus ~ case0).many) ∘ foldl(())(sumExpressionEq)
 
-    lazy val expression: C[Expression] = case1
+    val expression: C[Expression] = case1
   }
 
   def parse(s: String): Option[(String, Syntax.Expression)] =

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.0.1-SNAPSHOT"


### PR DESCRIPTION
Closes #42 

Allows codecs to be recursively used in definitions.