### PR TITLE
CFG

### DIFF
--- a/src/main/scala/scalaz/parsers/cfg.scala
+++ b/src/main/scala/scalaz/parsers/cfg.scala
@@ -1,0 +1,112 @@
+package scalaz.parsers
+
+import scalaz.parsers.tc.Alternative
+
+import scala.collection.mutable
+
+object cfg {
+
+  sealed trait CFG
+  case class Input(tag: String)                  extends CFG
+  case class Mapped(tag: String, node: CFG)      extends CFG
+  case class Seq(tag: String, node: List[CFG])   extends CFG
+  case class Alt(tag: String, node: List[CFG])   extends CFG
+  case class Many(tag: String, node: CFG)        extends CFG
+  case class Many1(tag: String, node: CFG)       extends CFG
+  case class Delay(tag: String, node: () => CFG) extends CFG
+
+  object CFG {
+
+    def tag: CFG => String = {
+      case Input(tag)     => tag
+      case Mapped(tag, _) => tag
+      case Seq(tag, _)    => tag
+      case Alt(tag, _)    => tag
+      case Many(tag, _)   => tag
+      case Many1(tag, _)  => tag
+      case Delay(tag, _)  => tag
+    }
+
+    def tagged(tag: String): CFG => CFG = {
+      case d @ Input(_)     => d.copy(tag = tag)
+      case d @ Mapped(_, _) => d.copy(tag = tag)
+      case d @ Seq(_, _)    => d.copy(tag = tag)
+      case d @ Alt(_, _)    => d.copy(tag = tag)
+      case d @ Many(_, _)   => d.copy(tag = tag)
+      case d @ Many1(_, _)  => d.copy(tag = tag)
+      case d @ Delay(_, _)  => d.copy(tag = tag)
+    }
+  }
+
+  case class CFGP[A](cfg: CFG) {
+
+    def show: List[String] =
+      CFGP.show(Nil)(List(cfg)).collect { case (n, v) if n.nonEmpty => s"<$n>$v" }.distinct
+  }
+
+  object CFGP {
+
+    def parserOps[F[_], G[_], E](P: Parsing[F, G, E]): P.ParserOps[CFGP] =
+      new P.ParserOps[CFGP] {
+        override def zip[A, B](p1: CFGP[A], p2: CFGP[B]): CFGP[A /\ B] =
+          CFGP(Seq("", List(p1.cfg, p2.cfg)))
+        override def alt[A, B](p1: CFGP[A], p2: CFGP[B])(
+          implicit AF: Alternative[F]
+        ): CFGP[A \/ B] =
+          CFGP(Alt("", List(p1.cfg, p2.cfg)))
+        override def map[A, B](p: CFGP[A])(equiv: P.Equiv[A, B]): CFGP[B] =
+          CFGP(Mapped("", p.cfg))
+        override def list[A](p: CFGP[A])(implicit AF: Alternative[F]): CFGP[List[A]] =
+          CFGP(Many("", p.cfg))
+        override def nel[A](e: E)(p: CFGP[A])(implicit AF: Alternative[F]): CFGP[List[A]] =
+          CFGP(Many1("", p.cfg))
+        override def tagged[A](t: String)(p: CFGP[A]): CFGP[A] =
+          p.copy(cfg = CFG.tagged(t)(p.cfg))
+      }
+
+    def show(z: List[String -> String])(cfg: List[CFG]): List[String -> String] = {
+      val visited: mutable.Set[CFG] = mutable.Set.empty
+
+      def show1(z: List[String -> String])(cfg: List[CFG]): List[String -> String] =
+        cfg.foldLeft(z)(
+          (acc, cfg) =>
+            if (visited.contains(cfg)) acc
+            else {
+              visited += cfg
+              (cfg match {
+                case Input(_) =>
+                  Nil
+                case Mapped(tag, d) =>
+                  show1(List(tag -> (" ::= " + show(d))))(List(d))
+                case Seq(tag, ds) =>
+                  show1(List(tag -> (" ::= " + ds.map(show).mkString(" "))))(ds)
+                case Alt(tag, ds) =>
+                  show1(List(tag -> (" ::= " + ds.map(show).mkString("(", " | ", ")"))))(ds)
+                case Many(tag, d) =>
+                  show1(List(tag -> (" ::= List(" + show(d) + ")")))(List(d))
+                case Many1(tag, d) =>
+                  show1(List(tag -> (" ::= NEL(" + show(d) + ")")))(List(d))
+                case Delay(tag, d) => show1(List(tag -> (" ::= " + show(d()))))(List(d()))
+              }) ::: acc
+            }
+        )
+
+      show1(z)(cfg)
+    }
+
+    private def show(node: CFG): String = {
+      val tag = CFG.tag(node)
+      if (tag.nonEmpty) s"<$tag>"
+      else
+        node match {
+          case Input(_)     => ""
+          case Mapped(_, d) => show(d)
+          case Seq(_, ds)   => ds.map(show).mkString(" ")
+          case Alt(_, ds)   => ds.map(show).mkString("(", " | ", ")")
+          case Many(_, d)   => "List(" + show(d) + ")"
+          case Many1(_, d)  => "NEL(" + show(d) + ")"
+          case Delay(_, d)  => show(d())
+        }
+    }
+  }
+}

--- a/src/test/scala/scalaz/parsers/DocumentationExampleSpec.scala
+++ b/src/test/scala/scalaz/parsers/DocumentationExampleSpec.scala
@@ -4,12 +4,15 @@ import org.specs2.mutable.Specification
 import scalaz.parsers.tc.{ Alternative, Category }
 import scalaz.std.either._
 
+import scala.collection.mutable
+
 class DocumentationExampleSpec extends Specification {
 
   object Syntax {
     sealed trait Expression
     case class Constant(value: Int)                                    extends Expression
     case class Operation(e1: Expression, op: Operator, e2: Expression) extends Expression
+    case class SubExpr(e: Expression)                                  extends Expression
 
     sealed trait Operator
     case object Add extends Operator
@@ -21,6 +24,7 @@ class DocumentationExampleSpec extends Specification {
 
     val parsing: Parsing[Either[String, ?], Either[String, ?], String] = Parsing()
     val equiv: parsing.Equiv.type                                      = parsing.Equiv
+    val codec: parsing.Codec.type                                      = parsing.Codec
     val syntax: parsing.syntax.type                                    = parsing.syntax
 
     type Equiv[A, B] = parsing.Equiv[A, B]
@@ -51,8 +55,11 @@ class DocumentationExampleSpec extends Specification {
       )
 
     def char: P[Char]
+    def delay[A](pa: => P[A]): P[A]
 
-    val digit: P[Char] = "digit" @@ (char ∘ ensure("Expected: [0-9]")(_.isDigit))
+    val digit: P[Char]  = "digit" @@ (char ∘ ensure("Expected: [0-9]")(_.isDigit))
+    val paren1: P[Char] = "(" @@ (char ∘ ensure("expected: open paren")(_ == '('))
+    val paren2: P[Char] = ")" @@ (char ∘ ensure("expected: close paren")(_ == ')'))
 
     val plus: P[Operator] = "+" @@ (char ∘ liftPartial("Expected: '+'")(
       { case '+' => Add }, { case Add => '+' }
@@ -70,22 +77,36 @@ class DocumentationExampleSpec extends Specification {
 
     val constant: P[Constant] = integer ∘ constantEq
 
-    val case0: P[Expression] = "Constant" @@ (constant ∘ constantExpressionEq)
+    val constExpr: P[Expression] = "Constant" @@ (constant ∘ constantExpressionEq)
+
+    val multiplier
+      : P[Expression] = "Multiplier" @@ ((paren1 ~ addition ~ paren2) | constExpr) ∘ lift({
+      case Left(((_, exp), _)) => SubExpr(exp)
+      case Right(exp)          => exp
+    }, {
+      case SubExpr(exp) => Left((('(', exp), ')'))
+      case exp          => Right(exp)
+    })
 
     // todo: how to get this error?
-    val case1: P[Expression] = (case0 ~ (star ~ case0).many) ∘ foldl("hm...")(
-      operationExpressionEq(Mul)
+    val multiplication: P[Expression] = "Multiplication" @@ (
+      (constExpr ~ (star ~ multiplier).many) ∘ foldl("hm...")(
+        operationExpressionEq(Mul)
+      )
     )
 
-    val case2: P[Expression] = (case1 ~ (plus ~ case1).many) ∘ foldl("hmm..")(
-      operationExpressionEq(Add)
-    )
+    lazy val addition: P[Expression] = "Addition" @@ delay {
+      (multiplication ~ (plus ~ multiplication).many) ∘ foldl("hmm..")(
+        operationExpressionEq(Add)
+      )
+    }
 
-    val expression: P[Expression] = "Expression" @@ case2
+    lazy val expression: P[Expression] = "Expression" @@ addition
   }
 
   object Parsers {
     import env.equiv
+    import env.codec
     import env.parsing.Codec
     import env.parsing.Codec._
 
@@ -96,39 +117,45 @@ class DocumentationExampleSpec extends Specification {
           { case (cs, c) => Right(cs :+ c) }
         )
       )
+
+      override def delay[A](pa: => Codec[List[Char], A]): Codec[List[Char], A] =
+        codec.delay(pa)
     }
 
     sealed trait Desc
-    case class Input(name: String)                 extends Desc
-    case class Mapped(name: String, desc: Desc)    extends Desc
-    case class Seq(name: String, desc: List[Desc]) extends Desc
-    case class Alt(name: String, desc: List[Desc]) extends Desc
-    case class Many(name: String, desc: Desc)      extends Desc
-    case class Many1(name: String, desc: Desc)     extends Desc
+    case class Input(tag: String)                   extends Desc
+    case class Mapped(tag: String, desc: Desc)      extends Desc
+    case class Seq(tag: String, desc: List[Desc])   extends Desc
+    case class Alt(tag: String, desc: List[Desc])   extends Desc
+    case class Many(tag: String, desc: Desc)        extends Desc
+    case class Many1(tag: String, desc: Desc)       extends Desc
+    case class Delay(tag: String, desc: () => Desc) extends Desc
 
     object Desc {
 
-      def name: Desc => String = {
-        case Input(name)     => name
-        case Mapped(name, _) => name
-        case Seq(name, _)    => name
-        case Alt(name, _)    => name
-        case Many(name, _)   => name
-        case Many1(name, _)  => name
+      def tag: Desc => String = {
+        case Input(tag)     => tag
+        case Mapped(tag, _) => tag
+        case Seq(tag, _)    => tag
+        case Alt(tag, _)    => tag
+        case Many(tag, _)   => tag
+        case Many1(tag, _)  => tag
+        case Delay(tag, _)  => tag
       }
 
-      def named(n: String): Desc => Desc = {
-        case d @ Input(_)     => d.copy(name = n)
-        case d @ Mapped(_, _) => d.copy(name = n)
-        case d @ Seq(_, _)    => d.copy(name = n)
-        case d @ Alt(_, _)    => d.copy(name = n)
-        case d @ Many(_, _)   => d.copy(name = n)
-        case d @ Many1(_, _)  => d.copy(name = n)
+      def tagged(t: String): Desc => Desc = {
+        case d @ Input(_)     => d.copy(tag = t)
+        case d @ Mapped(_, _) => d.copy(tag = t)
+        case d @ Seq(_, _)    => d.copy(tag = t)
+        case d @ Alt(_, _)    => d.copy(tag = t)
+        case d @ Many(_, _)   => d.copy(tag = t)
+        case d @ Many1(_, _)  => d.copy(tag = t)
+        case d @ Delay(_, _)  => d.copy(tag = t)
       }
 
       def show(desc: Desc): String = {
-        val name = Desc.name(desc)
-        if (name.nonEmpty) s"<$name>"
+        val tag = Desc.tag(desc)
+        if (tag.nonEmpty) s"<$tag>"
         else
           desc match {
             case Input(_)     => ""
@@ -137,6 +164,7 @@ class DocumentationExampleSpec extends Specification {
             case Alt(_, ds)   => ds.map(show).mkString("(", " | ", ")")
             case Many(_, d)   => "List(" + show(d) + ")"
             case Many1(_, d)  => "NEL(" + show(d) + ")"
+            case Delay(_, d)  => show(d())
           }
       }
     }
@@ -145,7 +173,8 @@ class DocumentationExampleSpec extends Specification {
     import env.parsing.ParserOps
 
     object Docs extends Grammar[Doc] {
-      override def char: Doc[Char] = Doc(Input("char"))
+      override def char: Doc[Char]                 = Doc(Input("char"))
+      override def delay[A](pa: => Doc[A]): Doc[A] = Doc(Delay("", () => pa.desc))
     }
 
     case class Doc[A](desc: Desc) {
@@ -156,20 +185,35 @@ class DocumentationExampleSpec extends Specification {
 
     object Doc {
 
-      def bnf(z: List[String -> String])(desc: List[Desc]): List[String -> String] =
-        desc.foldLeft(z)(
-          (acc, dd) =>
-            (dd match {
-              case Input(_)        => Nil
-              case Mapped(name, d) => bnf(List(name -> (" ::= " + Desc.show(d))))(List(d))
-              case Seq(name, ds) =>
-                bnf(List(name -> (" ::= " + ds.map(Desc.show).mkString(" "))))(ds)
-              case Alt(name, ds) =>
-                bnf(List(name -> (" ::= " + ds.map(Desc.show).mkString("(", " | ", ")"))))(ds)
-              case Many(name, d)  => bnf(List(name -> (" ::= List(" + Desc.show(d) + ")")))(List(d))
-              case Many1(name, d) => bnf(List(name -> (" ::= NEL(" + Desc.show(d) + ")")))(List(d))
-            }) ::: acc
-        )
+      def bnf(z: List[String -> String])(desc: List[Desc]): List[String -> String] = {
+        val visited: mutable.Set[Desc] = mutable.Set.empty
+
+        def bnf1(z: List[String -> String])(desc: List[Desc]): List[String -> String] =
+          desc.foldLeft(z)(
+            (acc, dd) =>
+              if (visited.contains(dd)) acc
+              else {
+                visited += dd
+                (dd match {
+                  case Input(_) =>
+                    Nil
+                  case Mapped(tag, d) =>
+                    bnf1(List(tag -> (" ::= " + Desc.show(d))))(List(d))
+                  case Seq(tag, ds) =>
+                    bnf1(List(tag -> (" ::= " + ds.map(Desc.show).mkString(" "))))(ds)
+                  case Alt(tag, ds) =>
+                    bnf1(List(tag -> (" ::= " + ds.map(Desc.show).mkString("(", " | ", ")"))))(ds)
+                  case Many(tag, d) =>
+                    bnf1(List(tag -> (" ::= List(" + Desc.show(d) + ")")))(List(d))
+                  case Many1(tag, d) =>
+                    bnf1(List(tag -> (" ::= NEL(" + Desc.show(d) + ")")))(List(d))
+                  case Delay(tag, d) => bnf1(List(tag -> (" ::= " + Desc.show(d()))))(List(d()))
+                }) ::: acc
+              }
+          )
+
+        bnf1(z)(desc)
+      }
 
       implicit def parserOps[I]: ParserOps[Doc] = new ParserOps[Doc] {
         type F[A] = Either[String, A]
@@ -184,7 +228,7 @@ class DocumentationExampleSpec extends Specification {
         override def nel[A](e: String)(p: Doc[A])(implicit AF: Alternative[F]): Doc[List[A]] =
           Doc(Many1("", p.desc))
         override def tagged[A](t: String)(p: Doc[A]): Doc[A] =
-          p.copy(desc = Desc.named(t)(p.desc))
+          p.copy(desc = Desc.tagged(t)(p.desc))
       }
     }
   }
@@ -200,12 +244,17 @@ class DocumentationExampleSpec extends Specification {
     "be available for all expression" in {
       Parsers.Docs.expression.bnf.mkString("\n", "\n", "\n") must_===
         """
+          |<+> ::= <char>
+          |<)> ::= <char>
+          |<Addition> ::= <Multiplication> List(<+> <Multiplication>)
+          |<(> ::= <char>
+          |<Multiplier> ::= (<(> <Addition> <)> | <Constant>)
+          |<*> ::= <char>
           |<digit> ::= <char>
           |<integer> ::= NEL(<digit>)
           |<Constant> ::= <integer>
-          |<*> ::= <char>
-          |<+> ::= <char>
-          |<Expression> ::= <Constant> List(<*> <Constant>) List(<+> <Constant> List(<*> <Constant>))
+          |<Multiplication> ::= <Constant> List(<*> <Multiplier>)
+          |<Expression> ::= <Multiplication> List(<+> <Multiplication>)
           |""".stripMargin
     }
   }
@@ -268,6 +317,25 @@ class DocumentationExampleSpec extends Specification {
           Operation(Constant(1), Mul, Constant(2)),
           Add,
           Operation(Constant(3), Mul, Constant(4))
+        )
+      )
+    }
+
+    "parse expressions with precedence" in {
+      parse("12*(34+56)") must_=== Right(
+        "" -> Operation(Constant(12), Mul, SubExpr(Operation(Constant(34), Add, Constant(56))))
+      )
+      parse("2*(3+4*5)") must_=== Right(
+        "" -> Operation(
+          Constant(2),
+          Mul,
+          SubExpr(
+            Operation(
+              Constant(3),
+              Add,
+              Operation(Constant(4), Mul, Constant(5))
+            )
+          )
         )
       )
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.1-SNAPSHOT"
+version in ThisBuild := "0.0.2-SNAPSHOT"


### PR DESCRIPTION
Closes #39 

1. Allows generation of context free grammars from parsers
2. Prints CFG into BNF-like structure

Code in `cfg` module is mostly extracted from samples and updated to handle recursive parser definitions. `DocumentationExample` is updated to have recursive parsers as well.