### PR TITLE
Fixed implementation of Alternative for EitherT

### DIFF
--- a/src/main/scala/scalaz/parsers/cfg.scala
+++ b/src/main/scala/scalaz/parsers/cfg.scala
@@ -41,26 +41,30 @@ object cfg {
   case class CFGP[A](cfg: CFG) {
 
     def show: List[String] =
-      CFGP.show(Nil)(List(cfg)).collect { case (n, v) if n.nonEmpty => s"<$n>$v" }.distinct
+      CFGP.show(Nil)(List(cfg)).collect { case (n, v) if n.nonEmpty => s"<$n>$v" }
   }
 
   object CFGP {
 
     def parserOps[F[_], G[_], E](P: Parsing[F, G, E]): P.ParserOps[CFGP] =
       new P.ParserOps[CFGP] {
-        override def zip[A, B](p1: CFGP[A], p2: CFGP[B]): CFGP[A /\ B] =
+
+        def zip[A, B](p1: CFGP[A], p2: CFGP[B]): CFGP[A /\ B] =
           CFGP(Seq("", List(p1.cfg, p2.cfg)))
-        override def alt[A, B](p1: CFGP[A], p2: CFGP[B])(
-          implicit AF: Alternative[F]
-        ): CFGP[A \/ B] =
+
+        def alt[A, B](p1: CFGP[A], p2: => CFGP[B])(implicit AF: Alternative[F]): CFGP[A \/ B] =
           CFGP(Alt("", List(p1.cfg, p2.cfg)))
-        override def map[A, B](p: CFGP[A])(equiv: P.Equiv[A, B]): CFGP[B] =
+
+        def map[A, B](p: CFGP[A])(equiv: P.Equiv[A, B]): CFGP[B] =
           CFGP(Mapped("", p.cfg))
-        override def list[A](p: CFGP[A])(implicit AF: Alternative[F]): CFGP[List[A]] =
+
+        def list[A](p: CFGP[A])(implicit AF: Alternative[F]): CFGP[List[A]] =
           CFGP(Many("", p.cfg))
-        override def nel[A](e: E)(p: CFGP[A])(implicit AF: Alternative[F]): CFGP[List[A]] =
+
+        def nel[A](e: E)(p: CFGP[A])(implicit AF: Alternative[F]): CFGP[List[A]] =
           CFGP(Many1("", p.cfg))
-        override def tagged[A](t: String)(p: CFGP[A]): CFGP[A] =
+
+        def tagged[A](t: String)(p: CFGP[A]): CFGP[A] =
           p.copy(cfg = CFG.tagged(t)(p.cfg))
       }
 

--- a/src/main/scala/scalaz/parsers/tc/Alternative.scala
+++ b/src/main/scala/scalaz/parsers/tc/Alternative.scala
@@ -1,7 +1,6 @@
 package scalaz.parsers.tc
 
-import scalaz.{ -\/, EitherT, Monad, \/- }
-import scalaz.syntax.monad._
+import scalaz.{ EitherT, Monad }
 
 trait Alternative[F[_]] {
   def or[A](f1: F[A], f2: => F[A]): F[A]
@@ -27,9 +26,6 @@ object Alternative {
   implicit def eitherTAlternative[F[_]: Monad, L]: Alternative[EitherT[L, F, ?]] =
     new Alternative[EitherT[L, F, ?]] {
       override def or[A](f1: EitherT[L, F, A], f2: => EitherT[L, F, A]): EitherT[L, F, A] =
-        EitherT(f1.run.flatMap {
-          case -\/(_) => f2.run
-          case \/-(_) => f1.run
-        })
+        f1.orElse(f2)
     }
 }

--- a/src/test/scala/scalaz/parsers/DocumentationExampleSpec.scala
+++ b/src/test/scala/scalaz/parsers/DocumentationExampleSpec.scala
@@ -77,14 +77,15 @@ class DocumentationExampleSpec extends Specification {
 
     val constExpr: P[Expression] = "Constant" @@ (constant ∘ constantExpressionEq)
 
-    val multiplier
-      : P[Expression] = "Multiplier" @@ ((paren1 ~ addition ~ paren2) | constExpr) ∘ lift({
-      case Left(((_, exp), _)) => SubExpr(exp)
-      case Right(exp)          => exp
-    }, {
-      case SubExpr(exp) => Left((('(', exp), ')'))
-      case exp          => Right(exp)
-    })
+    val multiplier: P[Expression] = "Multiplier" @@ (
+      ((paren1 ~ addition ~ paren2) | constExpr) ∘ lift({
+        case Left(((_, exp), _)) => SubExpr(exp)
+        case Right(exp)          => exp
+      }, {
+        case SubExpr(exp) => Left((('(', exp), ')'))
+        case exp          => Right(exp)
+      })
+    )
 
     // todo: how to get this error?
     val multiplication: P[Expression] = "Multiplication" @@ (

--- a/src/test/scala/scalaz/parsers/SimplestCodecSpec.scala
+++ b/src/test/scala/scalaz/parsers/SimplestCodecSpec.scala
@@ -3,6 +3,7 @@ package scalaz.parsers
 import org.specs2.mutable.Specification
 import scalaz.std.option._
 import scalaz.std.string._
+import scalaz.std.anyVal._
 
 class SimplestCodecSpec extends Specification {
 
@@ -46,9 +47,9 @@ class SimplestCodecSpec extends Specification {
       )
     )
 
-    val digit: C[Char] = char ∘ ensure(())(_.isDigit)
+    val digit: C[Char] = char ∘ ensure(_.isDigit)
 
-    val plus: C[Char] = char ∘ ensure(())(_ == '+')
+    val plus: C[Char] = char ∘ ensure(_ == '+')
 
     val integer: C[Int] = digit ∘ lift(_.toString.toInt, _.toString.head)
 


### PR DESCRIPTION
Closes #46 

@soujiro32167 It was my 🐛😬, what else could it be 😼

`Alternative.scala` has the fix.

@regis-leray we would need to redeploy the lib.